### PR TITLE
Moved modulus function down to avoid translation unit errors

### DIFF
--- a/examples/example_sdl_opengl3/Makefile
+++ b/examples/example_sdl_opengl3/Makefile
@@ -14,14 +14,14 @@
 #CXX = g++
 #CXX = clang++
 
-EXE = example_sdl_opengl3
+EXE = example_sdl2_opengl3
 #TEX_INSPECT_CHANGE...
 IMGUI_DIR = ../../../imgui
 TEX_INSPECT_DIR = ../..
 #...TEX_INSPECT_CHANGE
 SOURCES = main.cpp
 SOURCES += $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
-SOURCES += $(IMGUI_DIR)/backends/imgui_impl_sdl.cpp $(IMGUI_DIR)/backends/imgui_impl_opengl3.cpp
+SOURCES += $(IMGUI_DIR)/backends/imgui_impl_sdl2.cpp $(IMGUI_DIR)/backends/imgui_impl_opengl3.cpp
 #TEX_INSPECT_CHANGE...
 SOURCES += $(TEX_INSPECT_DIR)/imgui_tex_inspect.cpp $(TEX_INSPECT_DIR)/imgui_tex_inspect_demo.cpp
 SOURCES += $(TEX_INSPECT_DIR)/backends/tex_inspect_opengl.cpp 

--- a/imgui_tex_inspect.cpp
+++ b/imgui_tex_inspect.cpp
@@ -76,6 +76,10 @@ void Shutdown()
     // Nothing to do here.  But there might be in a later version. So client code should still call it!
 }
 
+Context *GetContext() {
+    return GContext;
+}
+
 Context *CreateContext()
 {
     GContext = IM_NEW(Context);

--- a/imgui_tex_inspect.cpp
+++ b/imgui_tex_inspect.cpp
@@ -434,6 +434,11 @@ void ReleaseInspectorData(ImGuiID ID)
     *inspector = Inspector();
 }
 
+Inspector *GetCurrentInspector()
+{
+    return GContext->CurrentInspector;
+}
+
 
 ImGuiID CurrentInspector_GetID()
 {

--- a/imgui_tex_inspect.cpp
+++ b/imgui_tex_inspect.cpp
@@ -27,6 +27,10 @@ bool GetVisibleTexelRegionAndGetData(Inspector *inspector, ImVec2 &texelTL, ImVe
 //-------------------------------------------------------------------------
 // [SECTION] GLOBAL STATE
 //-------------------------------------------------------------------------
+InputMap::InputMap()
+{
+    PanButton = ImGuiMouseButton_Left;
+}
 
 Context *GContext = nullptr;
 

--- a/imgui_tex_inspect.cpp
+++ b/imgui_tex_inspect.cpp
@@ -434,12 +434,6 @@ void ReleaseInspectorData(ImGuiID ID)
     *inspector = Inspector();
 }
 
-Inspector *GetCurrentInspector()
-{
-    return GContext->CurrentInspector;
-}
-
-
 ImGuiID CurrentInspector_GetID()
 {
     return GContext->CurrentInspector->ID;

--- a/imgui_tex_inspect.cpp
+++ b/imgui_tex_inspect.cpp
@@ -28,38 +28,6 @@ bool GetVisibleTexelRegionAndGetData(Inspector *inspector, ImVec2 &texelTL, ImVe
 // [SECTION] GLOBAL STATE
 //-------------------------------------------------------------------------
 
-// Input mapping structure, default values listed in the comments.
-struct InputMap
-{
-    ImGuiMouseButton PanButton; // LMB      enables panning when held
-    InputMap();
-};
-
-InputMap::InputMap()
-{
-    PanButton = ImGuiMouseButton_Left;
-}
-
-// Settings configured via SetNextPanelOptions etc.
-struct NextPanelSettings
-{
-    InspectorFlags ToSet = 0;
-    InspectorFlags ToClear = 0;
-};
-
-// Main context / configuration structure for imgui_tex_inspect
-struct Context
-{
-    InputMap                                    Input;                           // Input mapping config
-    ImGuiStorage                                Inspectors;                      // All the inspectors we've seen
-    Inspector *                                 CurrentInspector;                // Inspector currently being processed
-    NextPanelSettings                           NextPanelOptions;                // Options configured for next inspector panel
-    float                                       ZoomRate                 = 1.3f; // How fast mouse wheel affects zoom
-    float                                       DefaultPanelHeight       = 600;  // Height of panel in pixels
-    float                                       DefaultInitialPanelWidth = 600;  // Only applies when window first appears
-    int                                         MaxAnnotations           = 1000; // Limit number of texel annotations for performance
-};
-
 Context *GContext = nullptr;
 
 //-------------------------------------------------------------------------

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -2,11 +2,15 @@
 
 #pragma once
 #include "imgui.h"
+#include "imgui_tex_inspect_internal.h"
 
 namespace ImGuiTexInspect
 {
+
 struct Context;
 struct Transform2D;
+
+extern Context *GContext;
 //-------------------------------------------------------------------------
 // [SECTION] INIT & SHUTDOWN
 //-------------------------------------------------------------------------

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -21,6 +21,11 @@ void SetCurrentContext(Context *);
 // [SECTION] BASIC USAGE
 //-------------------------------------------------------------------------
 
+/*
+Gets the global context.
+*/
+Context *GetContext();
+
 enum InspectorAlphaMode
 {
     InspectorAlphaMode_ImGui,      // Alpha is transparency so you see the ImGui panel background behind image
@@ -112,6 +117,10 @@ void CurrentInspector_InvalidateTextureCache();
 void CurrentInspector_SetCustomBackgroundColor(ImVec4 color);
 void CurrentInspector_SetCustomBackgroundColor(ImU32 color);
 
+/*
+Returns the current inspector referenced by global context.
+*/
+Inspector *GetCurrentInspector();
 /* CurrentInspector_GetID
  * Get the ID of the current inspector.  Currently only used for calling
  * ReleaseInspectorData. 

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -5,6 +5,9 @@
 
 namespace ImGuiTexInspect
 {
+    struct Transform2D;
+    struct Context;
+    struct Inspector;
 //-------------------------------------------------------------------------
 // [SECTION] INIT & SHUTDOWN
 //-------------------------------------------------------------------------

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -2,15 +2,11 @@
 
 #pragma once
 #include "imgui.h"
-#include "imgui_tex_inspect_internal.h"
 
 namespace ImGuiTexInspect
 {
-
 struct Context;
 struct Transform2D;
-
-extern Context *GContext;
 //-------------------------------------------------------------------------
 // [SECTION] INIT & SHUTDOWN
 //-------------------------------------------------------------------------

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -2,6 +2,7 @@
 
 #pragma once
 #include "imgui.h"
+#include "imgui_tex_inspect_internal.h"
 
 namespace ImGuiTexInspect
 {

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -5,14 +5,47 @@
 
 namespace ImGuiTexInspect
 {
+struct Inspector;
 struct Context;
 struct Transform2D;
+
+
+// Input mapping structure, default values listed in the comments.
+struct InputMap
+{
+    ImGuiMouseButton PanButton; // LMB      enables panning when held
+    InputMap();
+};
+
+
+// Settings configured via SetNextPanelOptions etc.
+struct NextPanelSettings
+{
+    InspectorFlags ToSet = 0;
+    InspectorFlags ToClear = 0;
+};
+
+// Main context / configuration structure for imgui_tex_inspect
+struct Context
+{
+    InputMap                                    Input;                           // Input mapping config
+    ImGuiStorage                                Inspectors;                      // All the inspectors we've seen
+    Inspector *                                 CurrentInspector;                // Inspector currently being processed
+    NextPanelSettings                           NextPanelOptions;                // Options configured for next inspector panel
+    float                                       ZoomRate                 = 1.3f; // How fast mouse wheel affects zoom
+    float                                       DefaultPanelHeight       = 600;  // Height of panel in pixels
+    float                                       DefaultInitialPanelWidth = 600;  // Only applies when window first appears
+    int                                         MaxAnnotations           = 1000; // Limit number of texel annotations for performance
+};
+
+
 //-------------------------------------------------------------------------
 // [SECTION] INIT & SHUTDOWN
 //-------------------------------------------------------------------------
 void Init();
 void Shutdown();
 
+Context *GetContext();
 Context *CreateContext();
 void DestroyContext(Context *);
 void SetCurrentContext(Context *);

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -2,7 +2,6 @@
 
 #pragma once
 #include "imgui.h"
-#include "imgui_tex_inspect_internal.h"
 
 namespace ImGuiTexInspect
 {
@@ -118,10 +117,6 @@ void CurrentInspector_InvalidateTextureCache();
 void CurrentInspector_SetCustomBackgroundColor(ImVec4 color);
 void CurrentInspector_SetCustomBackgroundColor(ImU32 color);
 
-/*
-Returns the current inspector referenced by global context.
-*/
-Inspector *GetCurrentInspector();
 /* CurrentInspector_GetID
  * Get the ID of the current inspector.  Currently only used for calling
  * ReleaseInspectorData. 

--- a/imgui_tex_inspect.h
+++ b/imgui_tex_inspect.h
@@ -5,40 +5,6 @@
 
 namespace ImGuiTexInspect
 {
-struct Inspector;
-struct Context;
-struct Transform2D;
-
-
-// Input mapping structure, default values listed in the comments.
-struct InputMap
-{
-    ImGuiMouseButton PanButton; // LMB      enables panning when held
-    InputMap();
-};
-
-
-// Settings configured via SetNextPanelOptions etc.
-struct NextPanelSettings
-{
-    InspectorFlags ToSet = 0;
-    InspectorFlags ToClear = 0;
-};
-
-// Main context / configuration structure for imgui_tex_inspect
-struct Context
-{
-    InputMap                                    Input;                           // Input mapping config
-    ImGuiStorage                                Inspectors;                      // All the inspectors we've seen
-    Inspector *                                 CurrentInspector;                // Inspector currently being processed
-    NextPanelSettings                           NextPanelOptions;                // Options configured for next inspector panel
-    float                                       ZoomRate                 = 1.3f; // How fast mouse wheel affects zoom
-    float                                       DefaultPanelHeight       = 600;  // Height of panel in pixels
-    float                                       DefaultInitialPanelWidth = 600;  // Only applies when window first appears
-    int                                         MaxAnnotations           = 1000; // Limit number of texel annotations for performance
-};
-
-
 //-------------------------------------------------------------------------
 // [SECTION] INIT & SHUTDOWN
 //-------------------------------------------------------------------------

--- a/imgui_tex_inspect_internal.h
+++ b/imgui_tex_inspect_internal.h
@@ -31,13 +31,6 @@ static inline void ClearFlag(TSet &set, TFlag flag)
     set = static_cast<TSet>(set & ~flag);
 }
 
-// Proper modulus operator, as opposed to remainder as calculated by %
-template <typename T>
-static inline T Modulus(T a, T b)
-{
-    return a - b * ImFloorSigned(a / b);
-}
-
 // Defined in recent versions of imgui_internal.h.  Included here in case user is on older
 // imgui version.
 static inline float ImFloorSigned(float f)
@@ -48,6 +41,13 @@ static inline float ImFloorSigned(float f)
 static inline float Round(float f)
 {
     return ImFloorSigned(f + 0.5f);
+}
+
+// Proper modulus operator, as opposed to remainder as calculated by %
+template <typename T>
+static inline T Modulus(T a, T b)
+{
+    return a - b * ImFloorSigned(a / b);
 }
 
 static inline ImVec2 Abs(ImVec2 v)

--- a/imgui_tex_inspect_internal.h
+++ b/imgui_tex_inspect_internal.h
@@ -147,11 +147,6 @@ struct InputMap
     InputMap();
 };
 
-InputMap::InputMap()
-{
-    PanButton = ImGuiMouseButton_Left;
-}
-
 // Settings configured via SetNextPanelOptions etc.
 struct NextPanelSettings
 {

--- a/imgui_tex_inspect_internal.h
+++ b/imgui_tex_inspect_internal.h
@@ -139,6 +139,39 @@ struct Inspector
     ~Inspector();
 };
 
+
+// Input mapping structure, default values listed in the comments.
+struct InputMap
+{
+    ImGuiMouseButton PanButton; // LMB      enables panning when held
+    InputMap();
+};
+
+InputMap::InputMap()
+{
+    PanButton = ImGuiMouseButton_Left;
+}
+
+// Settings configured via SetNextPanelOptions etc.
+struct NextPanelSettings
+{
+    InspectorFlags ToSet = 0;
+    InspectorFlags ToClear = 0;
+};
+
+// Main context / configuration structure for imgui_tex_inspect
+struct Context
+{
+    InputMap                                    Input;                           // Input mapping config
+    ImGuiStorage                                Inspectors;                      // All the inspectors we've seen
+    Inspector *                                 CurrentInspector;                // Inspector currently being processed
+    NextPanelSettings                           NextPanelOptions;                // Options configured for next inspector panel
+    float                                       ZoomRate                 = 1.3f; // How fast mouse wheel affects zoom
+    float                                       DefaultPanelHeight       = 600;  // Height of panel in pixels
+    float                                       DefaultInitialPanelWidth = 600;  // Only applies when window first appears
+    int                                         MaxAnnotations           = 1000; // Limit number of texel annotations for performance
+};
+
 //-------------------------------------------------------------------------
 // [SECTION] INTERNAL FUNCTIONS
 //-------------------------------------------------------------------------


### PR DESCRIPTION
Self -explanatory, not sure if this is an MSVC thing where the compiler looks ahead for functions defined afterwards (I'm on linux), but on g++/nvcc I get errors that `ImFloorSigned` wasn't declared. 